### PR TITLE
Feature/check http status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,5 @@ There are many inputs available to customize the behavior of this action. Some a
 | `ssh_host`       | Yes      | N/A     | The SSH host to connect to.                                         |
 | `ssh_port`       | No       | `22`    | The SSH port to connect to.                                         |
 | `ssh_key`        | Yes      | N/A     | The SSH private key to use to connect to the server.                |
+| `attempts_opcache_reset_http` | No | `3` | The number of times to try the opcache reset HTTP request.       |
+| `attempts_opcache_reset_cli` | No | `1` | The number of times to try the opcache reset CLI command.         |

--- a/action.yml
+++ b/action.yml
@@ -35,10 +35,14 @@ inputs:
   ssh_key:
     description: 'The SSH key for connecting to the server'
     required: true
-  retries_opcache_reset_http:
-    description: 'The number of times to retry the opcache reset HTTP request'
+  attempts_opcache_reset_http:
+    description: 'The number of times to try the opcache reset HTTP request'
     required: false
     default: "3"
+  attempts_opcache_reset_cli:
+    description: 'The number of times to try the opcache reset CLI command'
+    required: false
+    default: "1"
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -53,4 +57,5 @@ runs:
     - ${{ inputs.ssh_host }}
     - ${{ inputs.ssh_port }}
     - ${{ inputs.ssh_key }}
-    - ${{ inputs.retries_opcache_reset_http }}
+    - ${{ inputs.attempts_opcache_reset_http }}
+    - ${{ inputs.attempts_opcache_reset_cli }}

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,10 @@ inputs:
   ssh_key:
     description: 'The SSH key for connecting to the server'
     required: true
+  retries_opcache_reset_http:
+    description: 'The number of times to retry the opcache reset HTTP request'
+    required: false
+    default: "3"
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -49,3 +53,4 @@ runs:
     - ${{ inputs.ssh_host }}
     - ${{ inputs.ssh_port }}
     - ${{ inputs.ssh_key }}
+    - ${{ inputs.retries_opcache_reset_http }}

--- a/run.sh
+++ b/run.sh
@@ -75,7 +75,7 @@ ssh -p $ssh_port -i repo_private_key $ssh_user@$ssh_host "chmod $octal_permissio
 echo "Running via CLI, just in case in use"
 opcache_reset_cli() {
     cli_exit_code=0
-    cli_result=$(ssh -p $ssh_port -i repo_private_key $ssh_user@$ssh_host "curl '$domain/opcache_reset.php' --resolve '$domain:127.0.0.1'")
+    cli_result=$(ssh -p $ssh_port -i repo_private_key $ssh_user@$ssh_host "$php_executable $webroot_path/opcache_reset.php")
     cli_status=$?
     if [ "$cli_result" = 'Failed to reset opcache' ]; then
         echo "FAILED TO RESET OPCACHE. RESET MANUALLY FOR CHANGES TO TAKE EFFECT"

--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,8 @@ ssh_user=$7
 ssh_host=$8
 ssh_port=$9
 ssh_key=${10}
-retries_opcache_reset_http=${11}
+attempts_opcache_reset_http=${11}
+attempts_opcache_reset_cli=${12}
 
 
 echo "Here's what we've got..."
@@ -29,7 +30,8 @@ echo "SSH User: $ssh_user"
 echo "SSH Host: $ssh_host"
 echo "SSH Port: $ssh_port"
 echo "SSH Key: $ssh_key"
-echo "Retries: $retries_opcache_reset_http"
+echo "Attempts Opcache Reset HTTP: $attempts_opcache_reset_http"
+echo "Attempts Opcache Reset CLI: $attempts_opcache_reset_cli"
 
 echo "Preparing SSH..."
 echo "$ssh_key" > repo_private_key
@@ -71,37 +73,65 @@ echo "Setting permissions"
 ssh -p $ssh_port -i repo_private_key $ssh_user@$ssh_host "chmod $octal_permissions $webroot_path/opcache_reset.php"
 
 echo "Running via CLI, just in case in use"
-cli_result=$(ssh -p $ssh_port -i repo_private_key $ssh_user@$ssh_host "$php_executable $webroot_path/opcache_reset.php")
-cli_status=$?
-
+opcache_reset_cli() {
+    cli_exit_code=0
+    cli_result=$(ssh -p $ssh_port -i repo_private_key $ssh_user@$ssh_host "curl '$domain/opcache_reset.php' --resolve '$domain:127.0.0.1'")
+    cli_status=$?
+    if [ "$cli_result" = 'Failed to reset opcache' ]; then
+        echo "FAILED TO RESET OPCACHE. RESET MANUALLY FOR CHANGES TO TAKE EFFECT"
+        cli_exit_code=1
+    elif [ "$cli_result" = 'No input file specified.' ]; then
+        echo "FAILED TO RESET OPCACHE. RESET MANUALLY FOR CHANGES TO TAKE EFFECT"
+        cli_exit_code=1
+    elif [ $cli_status -ne 0 ]; then
+        echo "FAILED TO RESET OPCACHE. RESET MANUALLY FOR CHANGES TO TAKE EFFECT"
+        cli_exit_code=1
+    fi
+    echo "CLI Result: $cli_result"
+    return $cli_exit_code
+}
+# Retry the CLI request if it fails
+cli_result=""
+cli_status=0
+for i in $(seq 1 "$attempts_opcache_reset_cli"); do
+    echo "Attempting CLI request $i of $attempts_opcache_reset_cli"
+    # Capture the result and exit code of the function
+    cli_result=$(opcache_reset_cli)
+    # If the function exits with a 0 status code, we're good
+    cli_status=$?
+    if [ $cli_status -eq 0 ]; then
+        break
+    fi
+done
 
 # We haven't encountered a situation where the CLI using opcache was an issue, so if it fails, it's *probably* not the end of the world and not worth failing the job
 echo "CLI Result: $cli_result"
 echo "CLI Status: $cli_status"
-# If HTTP gives us the failure message, let's fail the job
 
-exit_code=0
 echo "Running via HTTP"
 echo "URL: $domain/opcache_reset.php"
 opcache_reset_http() {
+    http_exit_code=0
     http_result=$(ssh -p $ssh_port -i repo_private_key $ssh_user@$ssh_host "curl '$domain/opcache_reset.php' --resolve '$domain:127.0.0.1'")
     http_status=$?
     if [ "$http_result" = 'Failed to reset opcache' ]; then
         echo "FAILED TO RESET OPCACHE. RESET MANUALLY FOR CHANGES TO TAKE EFFECT"
-        exit_code=1
+        http_exit_code=1
     elif [ "$http_result" = 'No input file specified.' ]; then
         echo "FAILED TO RESET OPCACHE. RESET MANUALLY FOR CHANGES TO TAKE EFFECT"
-        exit_code=1
+        http_exit_code=1
     elif [ $http_status -ne 0 ]; then
         echo "FAILED TO RESET OPCACHE. RESET MANUALLY FOR CHANGES TO TAKE EFFECT"
-        exit_code=1
+        http_exit_code=1
     fi
     echo "HTTP Result: $http_result"
-    return $exit_code
+    return $http_exit_code
 }
 # Retry the HTTP request if it fails
-for i in $(seq 1 "$retries_opcache_reset_http"); do
-    echo "Retrying HTTP request $i of $retries_opcache_reset_http"
+http_result=""
+http_status=0
+for i in $(seq 1 "$attempts_opcache_reset_http"); do
+    echo "Attempting HTTP request $i of $attempts_opcache_reset_http"
     # Capture the result and exit code of the function
     http_result=$(opcache_reset_http)
     # If the function exits with a 0 status code, we're good
@@ -116,5 +146,11 @@ echo "HTTP Status: $http_status"
 
 echo "Removing PHP script"
 ssh -p $ssh_port -i repo_private_key $ssh_user@$ssh_host "rm $webroot_path/opcache_reset.php"
+
+exit_code=0
+if [ $cli_status -ne 0 ] && [ $http_status -ne 0 ]; then
+    echo "FAILED TO RESET OPCACHE. RESET MANUALLY FOR CHANGES TO TAKE EFFECT"
+    exit_code=1
+fi
 
 exit $exit_code;

--- a/run.sh
+++ b/run.sh
@@ -15,6 +15,8 @@ ssh_user=$7
 ssh_host=$8
 ssh_port=$9
 ssh_key=${10}
+retries_opcache_reset_http=${11}
+
 
 echo "Here's what we've got..."
 echo "Domain: $domain"
@@ -27,6 +29,7 @@ echo "SSH User: $ssh_user"
 echo "SSH Host: $ssh_host"
 echo "SSH Port: $ssh_port"
 echo "SSH Key: $ssh_key"
+echo "Retries: $retries_opcache_reset_http"
 
 echo "Preparing SSH..."
 echo "$ssh_key" > repo_private_key
@@ -71,28 +74,45 @@ echo "Running via CLI, just in case in use"
 cli_result=$(ssh -p $ssh_port -i repo_private_key $ssh_user@$ssh_host "$php_executable $webroot_path/opcache_reset.php")
 cli_status=$?
 
-echo "Running via HTTP"
-echo "URL: $domain/opcache_reset.php"
-http_result=$(ssh -p $ssh_port -i repo_private_key $ssh_user@$ssh_host "curl '$domain/opcache_reset.php' --resolve '$domain:127.0.0.1'")
-http_status=$?
 
 # We haven't encountered a situation where the CLI using opcache was an issue, so if it fails, it's *probably* not the end of the world and not worth failing the job
 echo "CLI Result: $cli_result"
 echo "CLI Status: $cli_status"
 # If HTTP gives us the failure message, let's fail the job
+
+exit_code=0
+echo "Running via HTTP"
+echo "URL: $domain/opcache_reset.php"
+opcache_reset_http() {
+    http_result=$(ssh -p $ssh_port -i repo_private_key $ssh_user@$ssh_host "curl '$domain/opcache_reset.php' --resolve '$domain:127.0.0.1'")
+    http_status=$?
+    if [ "$http_result" = 'Failed to reset opcache' ]; then
+        echo "FAILED TO RESET OPCACHE. RESET MANUALLY FOR CHANGES TO TAKE EFFECT"
+        exit_code=1
+    elif [ "$http_result" = 'No input file specified.' ]; then
+        echo "FAILED TO RESET OPCACHE. RESET MANUALLY FOR CHANGES TO TAKE EFFECT"
+        exit_code=1
+    elif [ $http_status -ne 0 ]; then
+        echo "FAILED TO RESET OPCACHE. RESET MANUALLY FOR CHANGES TO TAKE EFFECT"
+        exit_code=1
+    fi
+    echo "HTTP Result: $http_result"
+    return $exit_code
+}
+# Retry the HTTP request if it fails
+for i in $(seq 1 "$retries_opcache_reset_http"); do
+    echo "Retrying HTTP request $i of $retries_opcache_reset_http"
+    # Capture the result and exit code of the function
+    http_result=$(opcache_reset_http)
+    # If the function exits with a 0 status code, we're good
+    http_status=$?
+    if [ $http_status -eq 0 ]; then
+        break
+    fi
+done
+
 echo "HTTP Result: $http_result"
 echo "HTTP Status: $http_status"
-exit_code=0
-if [[ "$http_result" == 'Failed to reset opcache' ]]; then
-    echo "FAILED TO RESET OPCACHE. RESET MANUALLY FOR CHANGES TO TAKE EFFECT"
-    exit_code=1
-elif [[ "$http_result" == 'No input file specified.' ]]; then
-    echo "FAILED TO RESET OPCACHE. RESET MANUALLY FOR CHANGES TO TAKE EFFECT"
-    exit_code=1
-elif [ $http_status -ne 0 ]; then
-    echo "FAILED TO RESET OPCACHE. RESET MANUALLY FOR CHANGES TO TAKE EFFECT"
-    exit_code=1
-fi
 
 echo "Removing PHP script"
 ssh -p $ssh_port -i repo_private_key $ssh_user@$ssh_host "rm $webroot_path/opcache_reset.php"


### PR DESCRIPTION
Hey, Theo!

I added retry params for both HTTP and CLI methods!

Is this ok to merge? I don't think this counts as backwards incompatible, since params default. I think it could be a **MINOR** version. If you agree, I can recreate the `v1` tag. Otherwise, I can create a `v2` tag.

To do after merged:

- [ ] Create new tag of action-opcache-reset (or replace `v1`)
- [ ] Update EZ Dock deploy.yml to reference new release of [action-opcache-reset](https://github.com/WebpageFX/ez-dock/blob/master/.github/workflows/deploy.yml)

Thanks!